### PR TITLE
Set routes as env and add private subnet to the defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,3 @@ FROM tailscale/tailscale:${UPSTREAM_VERSION}
 
 ENV TS_STATE_DIR=/var/lib/tailscale
 ENV TS_USERSPACE=false
-ENV TS_EXTRA_ARGS="--advertise-routes=${ADVERTISE_ROUTES}  --advertise-exit-node ${EXTRA_OPTS}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ FROM tailscale/tailscale:${UPSTREAM_VERSION}
 
 ENV TS_STATE_DIR=/var/lib/tailscale
 ENV TS_USERSPACE=false
-ENV TS_EXTRA_ARGS="--advertise-routes=172.33.0.0/16  --advertise-exit-node $EXTRA_OPTS"
+ENV TS_EXTRA_ARGS="--advertise-routes=${ADVERTISE_ROUTES}  --advertise-exit-node ${EXTRA_OPTS}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,9 @@ services:
     image: tailscale.dnp.dappnode.eth:0.1.0
     restart: unless-stopped
     environment:
-      - TS_AUTHKEY=
-      - ADVERTISE_ROUTES=172.33.0.0/16,10.20.0.0/24 # 172.33.0.0/16 is the current subnet in dappnode and 10.20.0.0/24 will be eventually used as the new subnet
-      - EXTRA_OPTS=
+      - TS_AUTHKEY= # https://tailscale.com/kb/1282/docker#ts_authkey
+      - TS_ROUTES=172.33.0.0/16,10.20.0.0/24 # https://tailscale.com/kb/1282/docker#ts_routes 172.33.0.0/16 is the current subnet in dappnode and 10.20.0.0/24 will be eventually used as the new subnet
+      - TS_EXTRA_ARGS=--advertise-exit-node # https://tailscale.com/kb/1282/docker#ts_extra_args
     volumes:
       - state:/var/lib/tailscale
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.5'
+version: "3.5"
 services:
   tailscale:
     build:
@@ -9,6 +9,7 @@ services:
     restart: unless-stopped
     environment:
       - TS_AUTHKEY=
+      - ADVERTISE_ROUTES=172.33.0.0/16,10.20.0.0/24 # 172.33.0.0/16 is the current subnet in dappnode and 10.20.0.0/24 will be eventually used as the new subnet
       - EXTRA_OPTS=
     volumes:
       - state:/var/lib/tailscale


### PR DESCRIPTION
Set routes as env and add private subnet to the defaults:
- `172.33.0.0/16` is the current subnet used in dappnode
- `10.20.0.0/24` will be eventually the new subnet to be used in dappnode