### PR TITLE
set TS_AUTH_ONCE to true

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,4 @@ FROM tailscale/tailscale:${UPSTREAM_VERSION}
 
 ENV TS_STATE_DIR=/var/lib/tailscale
 ENV TS_USERSPACE=false
+ENV TS_AUTH_ONCE=true

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -14,6 +14,9 @@
   "upstreamArg": "UPSTREAM_VERSION",
   "license": "GPL-3.0",
   "warnings": {
-    "onMinorUpdate": "When updating or reinstalling Tailscale, a new auth key might be required if the previous one is no longed valid (expired). You can check your current auth key status in the [Tailscale Admin Settings](https://login.tailscale.com/admin/settings/keys). If you encounter issues, generate a new auth key and update it in your Dappnode's Tailscale package settings. For more information see https://docs.dappnode.io/docs/user/access-your-dappnode/vpn/tailscale"
+    "onMinorUpdate": "A manual update in your Tailscale configuration is needed after installing this Tailscale version. First, update your custom DNS settings in your [Tailscale Admin UI](https://login.tailscale.com/admin/dns), ensuring that both \"dappnode\" and \"dappnode.private\" nameservers are set. Then, accept both subnet routes that appear in your Dappnode machine of [Tailscale Machines UI](https://login.tailscale.com/admin/machines). For more information, please refer to [Dappnode Docs](https://docs.dappnode.io/docs/user/access-your-dappnode/vpn/tailscale#3-configure-tailscale-to-connect-to-dappnode-internal-networks)."
+  },
+  "requirements" : {
+    "minimumDappnodeVersion": "0.3.2"
   }
 }


### PR DESCRIPTION
Ensures that tailscale only logs in with TS_AUTHKEY key once during the container lifecycle (time while its volumes are not removed). 

This can be useful to prevent errors when the user has an ephimeral TS_AUTHKEY.

By default, if state persists (`TS_STATE_DIR=/var/lib/tailscale` not deleted), tailscale will use the state there to authenticate and log in, so this is change is just a nice to have.
 