### PR TITLE
chore: bump tailscale to v1.98.8

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,22 +1,25 @@
 {
-  "name": "tailscale.dnp.dappnode.eth",
-  "version": "0.3.1",
-  "description": "Tailscale is a mesh VPN alternative that makes it easy to connect your devices securely.",
-  "type": "service",
+  "architectures": [
+    "linux/amd64",
+    "linux/arm64"
+  ],
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",
-  "links": {
-    "homepage": "https://tailscale.com",
-    "docs": "https://docs.dappnode.io/docs/user/access-your-dappnode/vpn/tailscale"
-  },
-  "architectures": ["linux/amd64", "linux/arm64"],
-  "upstreamVersion": "v1.98.5",
-  "upstreamRepo": "tailscale/tailscale",
-  "upstreamArg": "UPSTREAM_VERSION",
+  "description": "Tailscale is a mesh VPN alternative that makes it easy to connect your devices securely.",
   "license": "GPL-3.0",
-  "warnings": {
-    "onMinorUpdate": "A manual update in your Tailscale configuration is needed after installing this Tailscale version. First, update your custom DNS settings in your [Tailscale Admin UI](https://login.tailscale.com/admin/dns), ensuring that both \"dappnode\" and \"dappnode.private\" nameservers are set. Then, accept both subnet routes that appear in your Dappnode machine of [Tailscale Machines UI](https://login.tailscale.com/admin/machines). For more information, please refer to [Dappnode Docs](https://docs.dappnode.io/docs/user/access-your-dappnode/vpn/tailscale#3-configure-tailscale-to-connect-to-dappnode-internal-networks)."
+  "links": {
+    "docs": "https://docs.dappnode.io/docs/user/access-your-dappnode/vpn/tailscale",
+    "homepage": "https://tailscale.com"
   },
+  "name": "tailscale.dnp.dappnode.eth",
   "requirements": {
     "minimumDappnodeVersion": "0.3.2"
+  },
+  "type": "service",
+  "upstreamArg": "UPSTREAM_VERSION",
+  "upstreamRepo": "tailscale/tailscale",
+  "upstreamVersion": "v1.98.8",
+  "version": "0.3.1",
+  "warnings": {
+    "onMinorUpdate": "A manual update in your Tailscale configuration is needed after installing this Tailscale version. First, update your custom DNS settings in your [Tailscale Admin UI](https://login.tailscale.com/admin/dns), ensuring that both \"dappnode\" and \"dappnode.private\" nameservers are set. Then, accept both subnet routes that appear in your Dappnode machine of [Tailscale Machines UI](https://login.tailscale.com/admin/machines). For more information, please refer to [Dappnode Docs](https://docs.dappnode.io/docs/user/access-your-dappnode/vpn/tailscale#3-configure-tailscale-to-connect-to-dappnode-internal-networks)."
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        UPSTREAM_VERSION: v1.98.5
+        UPSTREAM_VERSION: v1.98.8
     image: tailscale.dnp.dappnode.eth:0.1.0
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Automated version bump triggered by release [`v1.98.8`](https://github.com/tailscale/tailscale/releases/tag/v1.98.8).

### Changes
- `upstream` version (`tailscale/tailscale`) → `v1.98.8`
- `UPSTREAM_VERSION` → `v1.98.8`

<!-- tropibot-release-bump -->