### PR TITLE
ci: use dappnode-build-hash reusable workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,11 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  push:
+    paths-ignore: ["README.md"]
+
+jobs:
+  build:
+    uses: dappnode/workflows/.github/workflows/dappnode-build-hash.yml@master
+    secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,17 @@
 name: "Main"
 on:
-  repository_dispatch:
   push:
+    branches:
+      - "master"
     paths-ignore:
       - "README.md"
+  repository_dispatch:
+  workflow_dispatch:
 
 jobs:
   release:
     name: Release
     runs-on: ipfs-dev-gateway
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master' || github.event_name == 'repository_dispatch'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     name: Release
     runs-on: ipfs-dev-gateway
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'repository_dispatch'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master' || github.event_name == 'repository_dispatch'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,30 +6,15 @@ on:
       - "README.md"
 
 jobs:
-  build-hash:
-    runs-on: ubuntu-latest
-    name: Build and post IPFS hash
-    if: github.event_name == 'push' && github.ref != 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-      - run: npx @dappnode/dappnodesdk github-action build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PINATA_API_KEY: ${{ secrets.PINATA_API_KEY }}
-          PINATA_SECRET_API_KEY: ${{ secrets.PINATA_SECRET_API_KEY }}
-
   release:
     name: Release
     runs-on: ipfs-dev-gateway
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'repository_dispatch'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
       - name: Log in to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Publish
@@ -37,4 +22,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEVELOPER_ADDRESS: "0xf35960302a07022aba880dffaec2fdd64d5bf1c1"
-          


### PR DESCRIPTION
## Context

This repo's build pipeline (an inlined `build-hash` job in `main.yml`) is now consolidated into a thin caller for the new `dappnode/workflows/.github/workflows/dappnode-build-hash.yml@master` reusable workflow. This produces a properly tagged IPFS hash comment authored by `tropibot[bot]` on every push to a non-default branch and on every PR.

## Approach

- `.github/workflows/build.yml` (new) — thin stub calling `dappnode-build-hash` with `secrets: inherit`. Triggers on `push` and `workflow_dispatch` only (no `pull_request`, since the `push` event already covers the build + comment case for tropibot PRs).
- `.github/workflows/main.yml` — slimmed to the release job only. The inlined `build-hash` job is removed; `actions/checkout` upgraded to v7; `actions/setup-node` to v6; Node 24.

## Test instructions

1. Push a commit to a feature branch (or open a test PR).
2. Verify the `Build` workflow runs **once** and posts a comment with an IPFS install link and hash tagged `(by dappnodebot/build-action)` and authored by `tropibot[bot]`.
3. After merge to the default branch, the `Main` workflow should run the release.